### PR TITLE
Xygeni-Bumper - update 38 dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <java.version>23</java.version>
     <jaxb.version>2.3.1</jaxb.version>
     <jjwt.version>0.9.1</jjwt.version>
-    <jose4j.version>0.9.3</jose4j.version>
+    <jose4j.version>0.9.6</jose4j.version>
     <jquery.version>3.7.1</jquery.version>
     <jsoup.version>1.19.1</jsoup.version>
     <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <webwolf.port>9090</webwolf.port>
     <wiremock.version>3.13.0</wiremock.version>
     <xml-resolver.version>1.2</xml-resolver.version>
-    <xstream.version>1.4.5</xstream.version>
+    <xstream.version>1.4.21</xstream.version>
     <!-- do not update necessary for lesson -->
     <zxcvbn.version>1.9.0</zxcvbn.version>
   </properties>


### PR DESCRIPTION
# 🛡️ Xygeni Bumper 
## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.7 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.7 
### 📝 Description 

CVE-2013-7285 Command Injection in Xstream - Xstream API versions up to 1.4.6 and version 1.4.10, if the security framework has not been initialized, may allow a remote attacker to run arbitrary shell commands by manipulating the processed input stream when unmarshaling XML or any supported format. e.g. JSON. 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2013-7285 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.16 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.16 
### 📝 Description 

CVE-2021-21341 XStream can cause a Denial of Service. - ### Impact
The vulnerability may allow a remote attacker to allocate 100% CPU time on the target system depending on CPU type or parallel execution of such a payload resulting in a denial of service only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
If you rely on XStream's default blacklist of the [Security Framework](https://x-stream.github.io/security.html#framework), you will have to use at least version 1.4.16.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-21341](https://x-stream.github.io/CVE-2021-21341.html).

### Credits
The vulnerability was discovered and reported by threedr3am.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user) 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-21341 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.18 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.18 
### 📝 Description 

CVE-2021-39153 XStream is vulnerable to an Arbitrary Code Execution attack - ### Impact
The vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream, if using the version out of the box with Java runtime version 14 to 8 or with JavaFX installed. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-39153](https://x-stream.github.io/CVE-2021-39153.html).

### Credits
Ceclin and YXXX from the Tencent Security Response Center found and reported the issue to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user)
 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-39153 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.18 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.18 
### 📝 Description 

CVE-2021-39147 XStream is vulnerable to an Arbitrary Code Execution attack - ### Impact
The vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-39147](https://x-stream.github.io/CVE-2021-39147.html).

### Credits
wh1t3p1g from TSRC (Tencent Security Response Center) found and reported the issue to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user)
 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-39147 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.14-java7 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.14-java7 
### 📝 Description 

CVE-2020-26217 XStream can be used for Remote Code Execution - ### Impact
The vulnerability may allow a remote attacker to run arbitrary shell commands only by manipulating the processed input stream.

### Patches
If you rely on XStream's default blacklist of the [Security Framework](https://x-stream.github.io/security.html#framework), you will have to use at least version 1.4.14.

### Workarounds
No user is affected, who followed the recommendation to setup XStream's Security Framework with a whitelist! Anyone relying on XStream's default blacklist can immediately switch to a whilelist for the allowed types to avoid the vulnerability.

Users of XStream 1.4.13 or below who still want to use XStream default blacklist can use a workaround depending on their version in use.

Users of XStream 1.4.13 can simply add two lines to XStream's setup code:
```Java
xstream.denyTypes(new String[]{ "javax.imageio.ImageIO$ContainsFilter" });
xstream.denyTypes(new Class[]{ java.lang.ProcessBuilder.class });
```
Users of XStream 1.4.12 to 1.4.7 who want to use XStream with a black list will have to setup such a list from scratch and deny at least the following types: _javax.imageio.ImageIO$ContainsFilter_, _java.beans.EventHandler_, _java.lang.ProcessBuilder_, _java.lang.Void_ and _void_.
```Java
xstream.denyTypes(new String[]{ "javax.imageio.ImageIO$ContainsFilter" });
xstream.denyTypes(new Class[]{ java.lang.ProcessBuilder.class, java.beans.EventHandler.class, java.lang.ProcessBuilder.class, java.lang.Void.class, void.class });
```
Users of XStream 1.4.6 or below can register an own converter to prevent the unmarshalling of the currently know critical types of the Java runtime. It is in fact an updated version of the workaround for CVE-2013-7285:
```Java
xstream.registerConverter(new Converter() {
  public boolean canConvert(Class type) {
    return type != null && (type == java.beans.EventHandler.class || type == java.lang.ProcessBuilder.class || type == java.lang.Void.class || void.class || type.getName().equals("javax.imageio.ImageIO$Con... 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2020-26217 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.20 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.20 
### 📝 Description 

CVE-2022-40151 XStream can cause a Denial of Service by injecting deeply nested objects raising a stack overflow - ### Impact
The vulnerability may allow a remote attacker to terminate the application with a stack overflow error resulting in a denial of service only by manipulating the processed input stream.

### Patches
XStream 1.4.20 handles the stack overflow and raises an InputManipulationException instead.

### Workarounds
The only solution is to catch the StackOverflowError in the client code calling XStream.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2022-40151](https://x-stream.github.io/CVE-2022-40151.html).

### Credits
The vulnerability was discovered and reported by Henry Lin of the Google OSS-Fuzz team.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user)
 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2022-40151 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.18 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.18 
### 📝 Description 

CVE-2021-39139 XStream is vulnerable to an Arbitrary Code Execution attack - ### Impact
The vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. A user is only affected if using the version out of the box with JDK 1.7u21 or below.  However, this scenario can be adjusted easily to an external Xalan that works regardless of the version of the Java runtime. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-39139](https://x-stream.github.io/CVE-2021-39139.html).

### Credits
Lai Han of nsfocus security team found and reported the issue to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user)
 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-39139 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.17 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.17 
### 📝 Description 

CVE-2021-29505 XStream is vulnerable to a Remote Command Execution attack - ### Impact
The vulnerability may allow a remote attacker has sufficient rights to execute commands of the host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
If you rely on XStream's default blacklist of the Security Framework, you will have to use at least version 1.4.17.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-29505](https://x-stream.github.io/CVE-2021-29505.html).

### Credits

V3geB1rd, white hat hacker from Tencent Security Response Center found and reported the issue to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Email us at [XStream Google Group](https://groups.google.com/group/xstream-user) 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-29505 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.18 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.18 
### 📝 Description 

CVE-2021-39146 XStream is vulnerable to an Arbitrary Code Execution attack - ### Impact
The vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-39146](https://x-stream.github.io/CVE-2021-39146.html).

### Credits
Ceclin and YXXX from the Tencent Security Response Center found and reported the issue to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user)
 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-39146 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.18 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.18 
### 📝 Description 

CVE-2021-39149 XStream is vulnerable to an Arbitrary Code Execution attack - ### Impact
The vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-39149](https://x-stream.github.io/CVE-2021-39149.html).

### Credits
Lai Han of NSFOCUS security team found and reported the issue to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user)
 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-39149 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.18 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.18 
### 📝 Description 

CVE-2021-39141 XStream is vulnerable to an Arbitrary Code Execution attack - ### Impact
The vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-39141](https://x-stream.github.io/CVE-2021-39141.html).

### Credits
Ceclin and YXXX from the Tencent Security Response Center found and reported the issue to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user)
 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-39141 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.18 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.18 
### 📝 Description 

CVE-2021-39148 XStream is vulnerable to an Arbitrary Code Execution attack - ### Impact
The vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-39148](https://x-stream.github.io/CVE-2021-39148.html).

### Credits
wh1t3p1g from TSRC (Tencent Security Response Center) found and reported the issue to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user)
 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-39148 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.20 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.20 
### 📝 Description 

CVE-2022-41966 XStream can cause Denial of Service via stack overflow - ### Impact
The vulnerability may allow a remote attacker to terminate the application with a stack overflow error resulting in a denial of service only by manipulating the processed input stream.

### Patches
XStream 1.4.20 handles the stack overflow and raises an InputManipulationException instead.

### Workarounds
The attack uses the hash code implementation for collections and maps to force recursive hash calculation causing a stack overflow. Following types of the Java runtime are affected:

- java.util.HashMap
- java.util.HashSet
- java.util.Hashtable
- java.util.LinkedHashMap
- java.util.LinkedHashSet
- Other third party collection implementations that use their element's hash code may also be affected

A simple solution is to catch the StackOverflowError in the client code calling XStream.

If your object graph does not use referenced elements at all, you may simply set the NO_REFERENCE mode:
```Java
XStream xstream = new XStream();
xstream.setMode(XStream.NO_REFERENCES);
```

If your object graph contains neither a Hashtable, HashMap nor a HashSet (or one of the linked variants of it) then you can use the security framework to deny the usage of these types:
```Java
XStream xstream = new XStream();
xstream.denyTypes(new Class[]{
 java.util.HashMap.class, java.util.HashSet.class, java.util.Hashtable.class, java.util.LinkedHashMap.class, java.util.LinkedHashSet.class
});
```

Unfortunately these types are very common. If you only use HashMap or HashSet and your XML refers these only as default map or set, you may additionally change the default implementation of java.util.Map and java.util.Set at unmarshalling time::
```Java
xstream.addDefaultImplementation(java.util.TreeMap.class, java.util.Map.class);
xstream.addDefaultImplementation(java.util.TreeSet.class, java.util.Set.class);
```
However, this implies that your application does not care about the implementation of the map and all elements are comparable.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2022-41966](https://x-stream.github.io/CVE-2022-41966.html).

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user)
 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2022-41966 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.9 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.9 
### 📝 Description 

CVE-2016-3674 XML External Entity Injection in XStream - Multiple XML external entity (XXE) vulnerabilities in the (1) Dom4JDriver, (2) DomDriver, (3) JDomDriver, (4) JDom2Driver, (5) SjsxpDriver, (6) StandardStaxDriver, and (7) WstxDriver drivers in XStream before 1.4.9 allow remote attackers to read arbitrary files via a crafted XML document. 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2016-3674 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.18 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.18 
### 📝 Description 

CVE-2021-39144 XStream is vulnerable to a Remote Command Execution attack - ### Impact
The vulnerability may allow a remote attacker has sufficient rights to execute commands of the host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-39144](https://x-stream.github.io/CVE-2021-39144.html).

### Credits

Ceclin and YXXX from the Tencent Security Response Center found and reported the issue to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Email us at [XStream Google Group](https://groups.google.com/group/xstream-user) 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-39144 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.19 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.19 
### 📝 Description 

CVE-2021-43859 Denial of Service by injecting highly recursive collections or maps in XStream - ### Impact
The vulnerability may allow a remote attacker to allocate 100% CPU time on the target system depending on CPU type or parallel execution of such a payload resulting in a denial of service only by manipulating the processed input stream.

### Patches
XStream 1.4.19 monitors and accumulates the time it takes to add elements to collections and throws an exception if a set threshold is exceeded.

### Workarounds
The attack uses the hash code implementation for collections and maps to force an exponential calculation time due to highly recursive structures with in the collection or map. Following types of the Java runtime are affected in Java versions available in December 2021:

- java.util.HashMap
- java.util.HashSet
- java.util.Hashtable
- java.util.LinkedHashMap
- java.util.LinkedHashSet
- java.util.Stack (older Java revisions only)
- java.util.Vector (older Java revisions only)
- Other third party collection implementations that use their element's hash code may also be affected

If your object graph does not use referenced elements at all, you may simply set the NO_REFERENCE mode:
```Java
XStream xstream = new XStream();
xstream.setMode(XStream.NO_REFERENCES);
```

If your object graph contains neither a Hashtable, HashMap nor a HashSet (or one of the linked variants of it) then you can use the security framework to deny the usage of these types:
```Java
XStream xstream = new XStream();
xstream.denyTypes(new Class[]{
 java.util.HashMap.class, java.util.HashSet.class, java.util.Hashtable.class, java.util.LinkedHashMap.class, java.util.LinkedHashSet.class
});
```

Unfortunately these types are very common. If you only use HashMap or HashSet and your XML refers these only as default map or set, you may additionally change the default implementation of java.util.Map and java.util.Set at unmarshalling time::
```Java
xstream.addDefaultImplementation(java.util.TreeMap.class, java.util.Map.class);
xstream.addDefaultImplementation(java.util.TreeSet.class, java... 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-43859 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.18 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.18 
### 📝 Description 

CVE-2021-39154 XStream is vulnerable to an Arbitrary Code Execution attack - ### Impact
The vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-39154](https://x-stream.github.io/CVE-2021-39154.html).

### Credits
ka1n4t found and reported the issue to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user)
 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-39154 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.18 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.18 
### 📝 Description 

CVE-2021-39145 XStream is vulnerable to an Arbitrary Code Execution attack - ### Impact
The vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-39145](https://x-stream.github.io/CVE-2021-39145.html).

### Credits
李安诺 (Li4n0) from Alibaba Cloud Security Team and Smi1e of DBAPPSecurity WEBIN Lab found and reported the issue independently to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user)
 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-39145 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.18 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.18 
### 📝 Description 

CVE-2021-39152 A Server-Side Forgery Request can be activated unmarshalling with XStream to access data streams from an arbitrary URL referencing a resource in an intranet or the local host - ### Impact
The vulnerability may allow a remote attacker to request data from internal resources that are not publicly available only by manipulating the processed input stream with a Java runtime version 14 to 8. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
If you rely on XStream's default blacklist of the [Security Framework](https://x-stream.github.io/security.html#framework), you will have to use at least version 1.4.18.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-39152](https://x-stream.github.io/CVE-2021-39152.html).

### Credits
m0d9 of the Security Team of Alibaba Cloud found and reported the issue to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user)
 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-39152 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.18 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.18 
### 📝 Description 

CVE-2021-39150 A Server-Side Forgery Request can be activated unmarshalling with XStream to access data streams from an arbitrary URL referencing a resource in an intranet or the local host - ### Impact
The vulnerability may allow a remote attacker to request data from internal resources that are not publicly available only by manipulating the processed input stream with a Java runtime version 14 to 8. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
If you rely on XStream's default blacklist of the [Security Framework](https://x-stream.github.io/security.html#framework), you will have to use at least version 1.4.18.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-39150](https://x-stream.github.io/CVE-2021-39150.html).

### Credits
Lai Han of NSFOCUS security team found and reported the issue to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user)
 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-39150 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.10 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.10 
### 📝 Description 

CVE-2017-7957 Denial of service in XStream - XStream through 1.4.9, when a certain denyTypes workaround is not used, mishandles attempts to create an instance of the primitive type 'void' during unmarshalling, leading to a remote application crash, as demonstrated by an xstream.fromXML("<void/>") call. 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2017-7957 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.18 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.18 
### 📝 Description 

CVE-2021-39151 XStream is vulnerable to an Arbitrary Code Execution attack - ### Impact
The vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-39151](https://x-stream.github.io/CVE-2021-39151.html).

### Credits
Smi1e of DBAPPSecurity WEBIN Lab found and reported the issue to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user)
 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-39151 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.21 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.21 
### 📝 Description 

CVE-2024-47072 XStream is vulnerable to a Denial of Service attack due to stack overflow from a manipulated binary input stream - ### Impact
The vulnerability may allow a remote attacker to terminate the application with a stack overflow error resulting in a denial of service only by manipulating the processed input stream when XStream is configured to use the BinaryStreamDriver.

### Patches
XStream 1.4.21 detects the manipulation in the binary input stream causing the the stack overflow and raises an InputManipulationException instead.

### Workarounds
The only solution is to catch the StackOverflowError in the client code calling XStream if XStream is configured to use the BinaryStreamDriver.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2024-47072](https://x-stream.github.io/CVE-2024-47072.html).

### Credits
Alexis Challande of Trail Of Bits found and reported the issue to XStream and provided the required information to reproduce it. 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2024-47072 



## Bumps org.bitbucket.b_c:jose4j:0.9.3 to 0.9.6 
### 🔍 Vulnerability Details 

- **Component:** org.bitbucket.b_c:jose4j 
- **Fixed Version:** 0.9.6 
### 📝 Description 

CVE-2024-29371 jose4j is vulnerable to DoS via compressed JWE content - In jose4j before 0.9.6, an attacker can cause a Denial-of-Service (DoS) condition by crafting a malicious JSON Web Encryption (JWE) token with an exceptionally high compression ratio. When this token is processed by the server, it results in significant memory allocation and processing time during decompression. 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2024-29371 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.16 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.16 
### 📝 Description 

CVE-2021-21344 XStream is vulnerable to an Arbitrary Code Execution attack - ### Impact
The vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
If you rely on XStream's default blacklist of the [Security Framework](https://x-stream.github.io/security.html#framework), you will have to use at least version 1.4.16.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-21344](https://x-stream.github.io/CVE-2021-21344.html).

### Credits
钟潦贵 (Liaogui Zhong) found and reported the issue to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user) 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-21344 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.16 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.16 
### 📝 Description 

CVE-2021-21343 XStream is vulnerable to an Arbitrary File Deletion on the local host when unmarshalling as long as the executing process has sufficient rights - ### Impact
The processed stream at unmarshalling time contains type information to recreate the formerly written objects.  XStream creates therefore new instances based on these type information.  An attacker can manipulate the processed input stream and replace or inject objects, that result in the deletion of a file on the local host. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
If you rely on XStream's default blacklist of the [Security Framework](https://x-stream.github.io/security.html#framework), you will have to use at least version 1.4.16.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-21343](https://x-stream.github.io/CVE-2021-21343.html).

### Credits
钟潦贵 (Liaogui Zhong) found and reported the issue to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user) 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-21343 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.16 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.16 
### 📝 Description 

CVE-2021-21351 XStream is vulnerable to an Arbitrary Code Execution attack - ### Impact
The vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
If you rely on XStream's default blacklist of the [Security Framework](https://x-stream.github.io/security.html#framework), you will have to use at least version 1.4.16.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-21351](https://x-stream.github.io/CVE-2021-21351.html).

### Credits
wh1t3p1g G5-RD6@IIE found and reported the issue to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user) 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-21351 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.16 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.16 
### 📝 Description 

CVE-2021-21342 A Server-Side Forgery Request can be activated unmarshalling with XStream to access data streams from an arbitrary URL referencing a resource in an intranet or the local host - ### Impact
The processed stream at unmarshalling time contains type information to recreate the formerly written objects. XStream creates therefore new instances based on these type information.  An attacker can manipulate the processed input stream and replace or inject objects, that result in a server-side forgery request. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
If you rely on XStream's default blacklist of the [Security Framework](https://x-stream.github.io/security.html#framework), you will have to use at least version 1.4.16

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-21342](https://x-stream.github.io/CVE-2021-21342.html).

### Credits
钟潦贵 (Liaogui Zhong) found and reported the issue to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user) 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-21342 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.16 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.16 
### 📝 Description 

CVE-2021-21345 XStream is vulnerable to a Remote Command Execution attack - ### Impact
The vulnerability may allow a remote attacker has sufficient rights to execute commands of the host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
If you rely on XStream's default blacklist of the [Security Framework](https://x-stream.github.io/security.html#framework), you will have to use at least version 1.4.16.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-21345](https://x-stream.github.io/CVE-2021-21345.html).

### Credits
钟潦贵 (Liaogui Zhong) found and reported the issue to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user) 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-21345 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.16 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.16 
### 📝 Description 

CVE-2021-21348 XStream is vulnerable to an attack using Regular Expression for a Denial of Service (ReDos) - ### Impact
The vulnerability may allow a remote attacker to occupy a thread that consumes maximum CPU time and will never return. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
If you rely on XStream's default blacklist of the [Security Framework](https://x-stream.github.io/security.html#framework), you will have to use at least version 1.4.16.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-21348](https://x-stream.github.io/CVE-2021-21348.html).

### Credits
The vulnerability was discovered and reported by threedr3am.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user) 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-21348 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.15 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.15 
### 📝 Description 

CVE-2020-26258 Server-Side Forgery Request can be activated unmarshalling with XStream - ### Impact
The vulnerability may allow a remote attacker to request data from internal resources that are not publicly available only by manipulating the processed input stream.

### Patches
If you rely on XStream's default blacklist of the [Security Framework](https://x-stream.github.io/security.html#framework), you will have to use at least version 1.4.15.

### Workarounds
The reported vulnerability does not exist running Java 15 or higher.

No user is affected, who followed the recommendation to setup XStream's Security Framework with a whitelist! Anyone relying on XStream's default blacklist can immediately switch to a whilelist for the allowed types to avoid the vulnerability.

Users of XStream 1.4.14 or below who still insist to use XStream default blacklist - despite that clear recommendation - can use a workaround depending on their version in use.

Users of XStream 1.4.14 can simply add two lines to XStream's setup code:
```Java
xstream.denyTypes(new String[]{ "jdk.nashorn.internal.objects.NativeString" });
xstream.denyTypesByRegExp(new String[]{ ".*\\.ReadAllStream\\$FileStream" });
```

Users of XStream 1.4.14 to 1.4.13 can simply add three lines to XStream's setup code:
```Java
xstream.denyTypes(new String[]{ "javax.imageio.ImageIO$ContainsFilter", "jdk.nashorn.internal.objects.NativeString" });
xstream.denyTypes(new Class[]{ java.lang.ProcessBuilder.class });
xstream.denyTypesByRegExp(new String[]{ ".*\\.ReadAllStream\\$FileStream" });
```
Users of XStream 1.4.12 to 1.4.7 who want to use XStream with a black list will have to setup such a list from scratch and deny at least the following types: _javax.imageio.ImageIO$ContainsFilter_, _java.beans.EventHandler_, _java.lang.ProcessBuilder_, _jdk.nashorn.internal.objects.NativeString.class_, _java.lang.Void_ and _void_ and deny several types by name pattern.
```Java
xstream.denyTypes(new String[]{ "javax.imageio.ImageIO$ContainsFilter", "jdk.nashorn.internal.objects.NativeString" });
xstream.denyTypes(ne... 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2020-26258 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.16 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.16 
### 📝 Description 

CVE-2021-21347 XStream is vulnerable to an Arbitrary Code Execution attack - ### Impact
The vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
If you rely on XStream's default blacklist of the [Security Framework](https://x-stream.github.io/security.html#framework), you will have to use at least version 1.4.16.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-21347](https://x-stream.github.io/CVE-2021-21347.html).

### Credits
The vulnerability was discovered and reported by threedr3am.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user) 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-21347 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.18 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.18 
### 📝 Description 

CVE-2021-39140 XStream can cause a Denial of Service - ### Impact
The vulnerability may allow a remote attacker to allocate 100% CPU time on the target system depending on CPU type or parallel execution of such a payload resulting in a denial of service only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-39140](https://x-stream.github.io/CVE-2021-39140.html).

### Credits
The vulnerability was discovered and reported by Lai Han of nsfocus security team.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user)
 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-39140 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.16 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.16 
### 📝 Description 

CVE-2021-21346 XStream is vulnerable to an Arbitrary Code Execution attack - ### Impact
The vulnerability may allow a remote attacker to load and execute arbitrary code from a remote host only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
If you rely on XStream's default blacklist of the [Security Framework](https://x-stream.github.io/security.html#framework), you will have to use at least version 1.4.16.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-21346](https://x-stream.github.io/CVE-2021-21346.html).

### Credits
wh1t3p1g G5-RD6@IIE found and reported the issue to XStream and provided the required information to reproduce it.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user) 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-21346 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.16 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.16 
### 📝 Description 

CVE-2021-21349 A Server-Side Forgery Request can be activated unmarshalling with XStream to access data streams from an arbitrary URL referencing a resource in an intranet or the local host - ### Impact
The vulnerability may allow a remote attacker to request data from internal resources that are not publicly available only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
If you rely on XStream's default blacklist of the [Security Framework](https://x-stream.github.io/security.html#framework), you will have to use at least version 1.4.16.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-21349](https://x-stream.github.io/CVE-2021-21349.html).

### Credits
The vulnerability was discovered and reported by threedr3am.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user) 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-21349 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.15 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.15 
### 📝 Description 

CVE-2020-26259 XStream vulnerable to an Arbitrary File Deletion on the local host when unmarshalling - ### Impact
The vulnerability may allow a remote attacker to delete arbitrary know files on the host as log as the executing process has sufficient rights only by manipulating the processed input stream.

### Patches
If you rely on XStream's default blacklist of the [Security Framework](https://x-stream.github.io/security.html#framework), you will have to use at least version 1.4.15.

### Workarounds
The reported vulnerability does only exist with a JAX-WS runtime on the classpath.

No user is affected, who followed the recommendation to setup XStream's Security Framework with a whitelist! Anyone relying on XStream's default blacklist can immediately switch to a whilelist for the allowed types to avoid the vulnerability.

Users of XStream 1.4.14 or below who still insist to use XStream default blacklist - despite that clear recommendation - can use a workaround depending on their version in use.

Users of XStream 1.4.14 can simply add two lines to XStream's setup code:
```Java
xstream.denyTypes(new String[]{ "jdk.nashorn.internal.objects.NativeString" });
xstream.denyTypesByRegExp(new String[]{ ".*\\.ReadAllStream\\$FileStream" });
```

Users of XStream 1.4.14 to 1.4.13 can simply add three lines to XStream's setup code:
```Java
xstream.denyTypes(new String[]{ "javax.imageio.ImageIO$ContainsFilter", "jdk.nashorn.internal.objects.NativeString" });
xstream.denyTypes(new Class[]{ java.lang.ProcessBuilder.class });
xstream.denyTypesByRegExp(new String[]{ ".*\\.ReadAllStream\\$FileStream" });
```
Users of XStream 1.4.12 to 1.4.7 who want to use XStream with a black list will have to setup such a list from scratch and deny at least the following types: _javax.imageio.ImageIO$ContainsFilter_, _java.beans.EventHandler_, _java.lang.ProcessBuilder_, _jdk.nashorn.internal.objects.NativeString.class_, _java.lang.Void_ and _void_ and deny several types by name pattern.
```Java
xstream.denyTypes(new String[]{ "javax.imageio.ImageIO$ContainsFilter", "jdk.nashorn.internal.objects... 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2020-26259 



## Bumps com.thoughtworks.xstream:xstream:1.4.5 to 1.4.16 
### 🔍 Vulnerability Details 

- **Component:** com.thoughtworks.xstream:xstream 
- **Fixed Version:** 1.4.16 
### 📝 Description 

CVE-2021-21350 XStream is vulnerable to an Arbitrary Code Execution attack - ### Impact
The vulnerability may allow a remote attacker to execute arbitrary code only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types.

### Patches
If you rely on XStream's default blacklist of the [Security Framework](https://x-stream.github.io/security.html#framework), you will have to use at least version 1.4.16.

### Workarounds
See [workarounds](https://x-stream.github.io/security.html#workaround) for the different versions covering all CVEs.

### References
See full information about the nature of the vulnerability and the steps to reproduce it in XStream's documentation for [CVE-2021-21350](https://x-stream.github.io/CVE-2021-21350.html).

### Credits
The vulnerability was discovered and reported by threedr3am.

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [XStream](https://github.com/x-stream/xstream/issues)
* Contact us at [XStream Google Group](https://groups.google.com/group/xstream-user) 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2021-21350 



## Bumps org.bitbucket.b_c:jose4j:0.9.3 to 0.9.4 
### 🔍 Vulnerability Details 

- **Component:** org.bitbucket.b_c:jose4j 
- **Fixed Version:** 0.9.4 
### 📝 Description 

CVE-2023-51775 jose4j denial of service via specifically crafted JWE - The jose4j component before 0.9.4 for Java allows attackers to cause a denial of service (CPU consumption) via a large p2c (aka PBES2 Count) value. 
### 🔗 References 

For more information, please refer to https://nvd.nist.gov/vuln/detail/CVE-2023-51775 



